### PR TITLE
refactor: 홈화면 레이아웃 화면 크기에 따라 반응되도록 설정 / max-width는 800px로 설정

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -3,50 +3,56 @@ import BottomNavItem from "./BottomNavItem";
 import { useEffect, useState } from "react";
 
 const BottomNav = () => {
-    const [selectedMenu, setSelectedMenu] = useState("home");
-    const location = useLocation();
+  const [selectedMenu, setSelectedMenu] = useState("home");
+  const location = useLocation();
 
-    useEffect(() => {
-        const selected = location.pathname;
-        if (selected === "/home" || selected === "/contents" || selected === "/ems" || selected === "/my") {
-            setSelectedMenu(selected);
-        }
-    }, [location.pathname]);
+  useEffect(() => {
+    const selected = location.pathname;
+    if (
+      selected === "/home" ||
+      selected === "/contents" ||
+      selected === "/ems" ||
+      selected === "/my"
+    ) {
+      setSelectedMenu(selected);
+    }
+  }, [location.pathname]);
 
-    return (
-        <div
-            className="flex flex-row justify-between items-center
-        w-[393px] h-10 pt-4 pl-5 pr-5 bg-white border-t border-gray-200 box-border"
-        >
-            <BottomNavItem
-                imageOnSrc="/icons/Home-icon-on.svg"
-                imageOffSrc="/icons/Home-icon-off.svg"
-                isSelected={selectedMenu === "/home"}
-                text="홈"
-            />
+  return (
+    <div
+      className="flex flex-row justify-between items-center
+        h-10 pt-8 pl-5 pr-5 pb-13
+         bg-white border-t border-gray-200 box-border z-50"
+    >
+      <BottomNavItem
+        imageOnSrc="/icons/Home-icon-on.svg"
+        imageOffSrc="/icons/Home-icon-off.svg"
+        isSelected={selectedMenu === "/home"}
+        text="홈"
+      />
 
-            <BottomNavItem
-                imageOnSrc="/icons/Contents-icon-on.svg"
-                imageOffSrc="/icons/Contents-icon-off.svg"
-                isSelected={selectedMenu === "/create"}
-                text="콘텐츠"
-            />
+      <BottomNavItem
+        imageOnSrc="/icons/Contents-icon-on.svg"
+        imageOffSrc="/icons/Contents-icon-off.svg"
+        isSelected={selectedMenu === "/create"}
+        text="콘텐츠"
+      />
 
-            <BottomNavItem
-                imageOnSrc="/icons/EMSInteract-icon-on.svg"
-                imageOffSrc="/icons/EMSInteract-icon-off.svg"
-                isSelected={selectedMenu === "/create"}
-                text="긴급대응"
-            />
+      <BottomNavItem
+        imageOnSrc="/icons/EMSInteract-icon-on.svg"
+        imageOffSrc="/icons/EMSInteract-icon-off.svg"
+        isSelected={selectedMenu === "/create"}
+        text="긴급대응"
+      />
 
-            <BottomNavItem
-                imageOnSrc="/icons/My-icon-on.svg"
-                imageOffSrc="/icons/My-icon-off.svg"
-                isSelected={selectedMenu === "/my"}
-                text="마이"
-            />
-        </div>
-    );
+      <BottomNavItem
+        imageOnSrc="/icons/My-icon-on.svg"
+        imageOffSrc="/icons/My-icon-off.svg"
+        isSelected={selectedMenu === "/my"}
+        text="마이"
+      />
+    </div>
+  );
 };
 
 export default BottomNav;

--- a/src/components/BottomNavItem.tsx
+++ b/src/components/BottomNavItem.tsx
@@ -20,26 +20,26 @@ const BottomNavItem = ({
   return (
     <>
       {isSelected ? (
-        <div
+        <button
           className="flex flex-col w-25 h-7 justify-center items-center 
-                bg-[#FFFFFF] rounded-[10px]"
+                bg-[#FFFFFF] rounded-[10px] cursor-pointer"
           onClick={handleClick}
         >
           <img className="w-6 h-6" src={imageOnSrc} />
           <div className="text-center justify-start text-blue-500 text-xs font-extrabold font-pretendard">
             {text}
           </div>
-        </div>
+        </button>
       ) : (
-        <div
-          className="flex flex-col w-25 h-7 justify-center items-center"
+        <button
+          className="flex flex-col w-25 h-7 justify-center items-center cursor-pointer"
           onClick={handleClick}
         >
           <img className="w-6 h-6" src={imageOffSrc} />
           <div className="text-center justify-start text-gray-400 text-xs font-medium font-pretendard">
             {text}
           </div>
-        </div>
+        </button>
       )}
     </>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -80,10 +80,9 @@
 }
 
 body {
-  margin: 0;
-  /* display: flex; */
-  place-items: center;
-  min-width: 393px;
-  min-height: 856px;
+  margin: 0 auto;
+  /* place-items: center; */
+  max-width: 800px;
+  min-width: 360px;
   font-family: "Pretendard";
 }

--- a/src/layouts/HomeLayout.tsx
+++ b/src/layouts/HomeLayout.tsx
@@ -2,13 +2,14 @@ import { Outlet } from "react-router-dom";
 import BottomNav from "../components/BottomNav";
 
 const HomeLayout = () => {
-    return (
-        <div className="flex flex-col justify-between w-[390px] h-[844px]">
-            <main className="relative flex flex-col justify-between  bg-[#ffffff]">
-                <Outlet /> {/* 홈 페이지 등 상단, 하단바 필요한 페이지가 여기에 렌더링됨 */}
-            </main>
-            <BottomNav/>
-        </div>
-    )
-}
+  return (
+    <div className="flex flex-col justify-between w-full h-full">
+      <main className="h-[calc(100vh-85px)] bg-[#ffffff] overflow-hidden overflow-y-auto no-scrollbar">
+        <Outlet />{" "}
+        {/* 홈 페이지 등 상단, 하단바 필요한 페이지가 여기에 렌더링됨 */}
+      </main>
+      <BottomNav />
+    </div>
+  );
+};
 export default HomeLayout;

--- a/src/pages/HomePage/FraudCheck.tsx
+++ b/src/pages/HomePage/FraudCheck.tsx
@@ -1,36 +1,33 @@
 const FraudCheck = () => {
-
-
-    return (
-        <div
-            className="flex flex-col justify-between w-[344px] h-52 relative mt-39 mb-4 p-4
+  return (
+    <div
+      className="flex flex-col gap-16 w-full relative mt-35 mb-6 p-4 pt-3 
                  bg-white rounded-[20px] not-last-of-type:outline-2 outline-offset-[-2px] outline-white/60 backdrop-blur-sm"
-        >
-            <div>
-                <div className="mb-1 justify-start text-slate-950 text-2xl font-bold font-pretendard leading-7">
-                    사기 의심 상황 분석
-                </div>
-                <div className="w-full justify-center text-blue-500 text-base font-medium font-pretendard leading-normal">
-                    AI 분석을 통해 다양한 상황에 따른
-                    <br />
-                    사기 가능성과 사기 유형에 대한 <br />
-                    레포트 제공
-                </div>
-            </div>
-            <div>
-                <div className="absolute left-53 bottom-6 z-[-1]">
-                    <img src="public/Blockee.svg" alt="캐릭터" />
-                </div>
-                <button
-                    className="w-[310px] h-11 py-1.5 z-10
+    >
+      <div>
+        <span className="mb-1 justify-start text-slate-950 text-2xl font-bold leading-9 line">
+          사기 의심 상황 분석
+        </span>
+        <div className="w-full justify-center text-blue-500 text-base font-normal leading-normal">
+          AI 분석을 통해 다양한 상황에 따른
+          <br />
+          사기 가능성과 사기 유형에 대한 레포트 제공
+        </div>
+      </div>
+      <div className="relative">
+        <div className="absolute right-1 bottom-3.5 z-[-1]">
+          <img src="public/Blockee.svg" alt="캐릭터" />
+        </div>
+        <button
+          className="w-full h-11 py-1.5 z-10 
                     bg-gradient-to-br from-blue-400 to-green-300 
                     rounded-[10px] justify-center items-center text-white text-lg font-semibold font-pretendard"
-                >
-                    시작하기
-                </button>
-            </div>
-        </div>
-    )
-}
+        >
+          시작하기
+        </button>
+      </div>
+    </div>
+  );
+};
 
 export default FraudCheck;

--- a/src/pages/HomePage/HomeCheck.tsx
+++ b/src/pages/HomePage/HomeCheck.tsx
@@ -2,34 +2,33 @@ import FraudCheck from "./FraudCheck";
 import LinkNumberCheck from "./LinkNumberCheck";
 
 const HomeCheck = () => {
+  return (
+    <div className="w-full relative p-6 pb-9 bg-blue-500 rounded-bl-[20px] rounded-br-[20px]">
+      <div className="justify-start text-blue-50 text-base font-bold font-pretendard leading-loose">
+        Block Guard
+      </div>
 
-    return (
-        <div className="w-full h-[718px] relative p-6 bg-blue-500 rounded-bl-[20px] rounded-br-[20px]">
-            <div className="justify-start text-blue-50 text-base font-bold font-pretendard leading-loose">
-                Block Guard
-            </div>
+      <div className="justify-start text-white text-3xl font-extrabold font-pretendard leading-loose">
+        피싱 사기가 의심 되시나요?
+      </div>
 
-            <div className="justify-start text-white text-3xl font-extrabold font-pretendard leading-loose">
-                피싱 사기가 의심 되시나요?
-            </div>
+      <div className="justify-center text-gray-200 text-lg font-normal font-pretendard leading-normal">
+        의심스러운 상황에 대해 설명해주시면
+        <br />
+        블락이가 피싱여부를 분석해드려요!
+      </div>
 
-            <div className="justify-center text-gray-200 text-lg font-normal font-pretendard leading-normal">
-                의심스러운 상황에 대해 설명해주시면
-                <br />
-                블락이가 피싱여부를 분석해드려요!
-            </div>
+      <img
+        src="/public/homeBackgroundShield.svg"
+        className="absolute right-0 top-33"
+      />
 
-            <img
-                src="/public/homeBackgroundShield.svg"
-                className="absolute right-0 top-33"
-            />
-
-            <div className="flex flex-col items-center">
-                <FraudCheck />
-                <LinkNumberCheck />
-            </div>
-        </div>
-    )
-}
+      <div className="flex flex-col items-center">
+        <FraudCheck />
+        <LinkNumberCheck />
+      </div>
+    </div>
+  );
+};
 
 export default HomeCheck;

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -2,39 +2,42 @@ import HomeCheck from "./HomeCheck";
 
 const HomePage = () => {
   return (
-    <div className="h-[800px] overflow-y-scroll no-scrollbar">
-     
-    <HomeCheck/>
+    <div className="overflow-y-scroll no-scrollbar mb-10 flex flex-col gap-10">
+      <HomeCheck />
 
-      <div className="justify-center text-slate-950 text-xl font-bold font-pretendard leading-loose">
-        바로 신고 및 대응
-      </div>
+      <div>
+        <div className="justify-center text-slate-950 text-xl font-bold font-pretendard leading-loose">
+          바로 신고 및 대응
+        </div>
 
-      <div className="w-80 px-5 py-3.5 bg-[#EEF1F3] rounded-[20px] outline-2 outline-offset-[-2px] outline-white/60 inline-flex flex-col justify-start items-start gap-2">
-        <div className="flex flex-row">
+        <div className="w-80 px-5 py-3.5 bg-[#EEF1F3] rounded-[20px] outline-2 outline-offset-[-2px] outline-white/60 inline-flex flex-col justify-start items-start gap-2">
           <div className="flex flex-row">
-            <div className="justify-center text-slate-950 text-xl font-bold font-pretendard leading-loose">
-              상활별 가이드 바로가기
+            <div className="flex flex-row">
+              <div className="justify-center text-slate-950 text-xl font-bold font-pretendard leading-loose">
+                상활별 가이드 바로가기
+              </div>
+              <img src="icons/Siren-icon.svg" alt="사이렌 아이콘" />
             </div>
-            <img src="icons/Siren-icon.svg" alt="사이렌 아이콘" />
+
+            <img src="icons/RightArrow-icon.svg" alt="오른쪽 화살표" />
           </div>
 
-          <img src="icons/RightArrow-icon.svg" alt="오른쪽 화살표" />
-        </div>
-
-        <div className="justify-center text-gray-400 text-base font-normal font-pretendard leading-tight">
-          이미 사기를 당하셨나요?
-          <br />
-          버튼을 눌러 바로 신고 조치를 취할 수 있어요
+          <div className="justify-center text-gray-400 text-base font-normal font-pretendard leading-tight">
+            이미 사기를 당하셨나요?
+            <br />
+            버튼을 눌러 바로 신고 조치를 취할 수 있어요
+          </div>
         </div>
       </div>
 
-      <div className="justify-center text-slate-950 text-xl font-bold font-pretendard leading-loose">
-        최신 뉴스
-      </div>
+      <div>
+        <div className="justify-center text-slate-950 text-xl font-bold font-pretendard leading-loose">
+          최신 뉴스
+        </div>
 
-      <div className="w-60 pb-3.5 bg-gray-100 rounded-[20px] outline-2 outline-offset-[-2px] outline-white/60 inline-flex flex-col justify-start items-center gap-2.5 overflow-hidden">
-        기사 이미지 기사 제목 기사 메타 정보 가로로 리스트 반복
+        <div className="w-60 pb-3.5 bg-gray-100 rounded-[20px] outline-2 outline-offset-[-2px] outline-white/60 inline-flex flex-col justify-start items-center gap-2.5 overflow-hidden">
+          기사 이미지 기사 제목 기사 메타 정보 가로로 리스트 반복
+        </div>
       </div>
     </div>
   );

--- a/src/pages/HomePage/LinkNumberCheck.tsx
+++ b/src/pages/HomePage/LinkNumberCheck.tsx
@@ -1,34 +1,35 @@
 import { useState } from "react";
 
 const LinkNumberCheck = () => {
+  const [urlNumber, setUrlNumber] = useState("");
 
-    const [urlNumber, setUrlNumber] = useState('');
-
-    const activeEnter = (e) => {
-        if (e.key === "Enter") {
-            alert(urlNumber); //임시
-        }
+  const activeEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      alert(urlNumber); //임시
     }
+  };
 
-    return (
-        <div
-            className="flex flex-col justify-between w-[344px] h-28 pr-4 pl-4 pb-4 pt-3
+  return (
+    <div
+      className="flex flex-col justify-between w-full h-28 pr-4 pl-4 pb-4 pt-3
                  bg-white/10 rounded-[20px] border-2 border-white/60"
-        >
-            <div className="justify-center text-white text-2xl font-bold leading-9">
-                클릭 한 번으로 위험 확인
-            </div>
-            <div className="flex flex-row text-white/50 text-sm font-medium leading-none">
-                <img src="icons/Search-icon.svg" className="mr-1" alt="돋보기 아이콘" />
-                <input type="text" 
-                    className="w-full focus:outline-none focus:ring-0 text-white text-sm font-medium leading-none" 
-                    onChange={(e) => setUrlNumber(e.target.value)}
-                    onKeyDown={(e) => activeEnter(e)}
-                    placeholder="URL / 전화번호를 검색해보세요" />
-            </div>
-            <div className="w-78 h-0.5 bg-white rounded-[90px]" />
-        </div>
-    )
-}
+    >
+      <div className="justify-center text-white text-2xl font-bold leading-9">
+        클릭 한 번으로 위험 확인
+      </div>
+      <div className="flex flex-row text-white/50 text-sm font-medium leading-none">
+        <img src="icons/Search-icon.svg" className="mr-1" alt="돋보기 아이콘" />
+        <input
+          type="text"
+          className="w-full focus:outline-none focus:ring-0 text-white text-sm font-medium leading-none"
+          onChange={(e) => setUrlNumber(e.target.value)}
+          onKeyDown={(e) => activeEnter(e)}
+          placeholder="URL / 전화번호를 검색해보세요"
+        />
+      </div>
+      <div className="w-78 h-0.5 bg-white rounded-[90px]" />
+    </div>
+  );
+};
 
 export default LinkNumberCheck;


### PR DESCRIPTION
## 🐣Title
- 홈화면 디스플레이 너비, 높이에 따라 대응되도록 수정. 

<br/>

## 🐣Key Changes

- 바로 신고 및 대응, 최신 뉴스를 제외한 컴포넌트들의 스타일링 수정(바텀바 포함)
- 800px이 넘어가면 더이상 화면이 늘어나지 않도록 body의 max-width를 800px로 설정

<br/>

## 🐣Simulation

- 개발자 도구 iPhone 12 pro일 
![image](https://github.com/user-attachments/assets/c719a0b2-2788-4646-bdd1-2c9f7656858d)

- 800px이 넘어갔을 때
![image](https://github.com/user-attachments/assets/14f399f1-89d3-4120-813a-149cf0d4e82c)

<br/>

## 🐣To Reviewer

- 스타일링 하실 때 정적인 이미지 등을 제외하고는 대부분 고정된 픽셀값을 사용하지 않는 것이 좋을 것 같습니다.
- 이부분은 저와 맞추어 가면 코딩 스타일을 맞춰야 할 것 같은데 pr 보시고 피드백 해주세요.

<br/>

## 🐣Next

- 버튼, 헤더 등의 공통 컴포넌트 구현