### PR TITLE
feat: 보이스피싱 대응기관 페이지 구현

### DIFF
--- a/src/pages/Emergency/EmergencyMain/EmergencyMainPage.tsx
+++ b/src/pages/Emergency/EmergencyMain/EmergencyMainPage.tsx
@@ -1,52 +1,21 @@
+import { useNavigate } from "react-router-dom";
 import ReportProgressCard from "../../../components/ReportProgressCard/ReportProgressCard";
 import EmergencyResponseStart from "./components/EmergencyResponseStart";
 import OrganCard from "./components/OrganCard";
 import QuickReportCard from "./components/QuickReportCard";
+import { dummyOrgan } from "../organList";
 
 let currentProgress = 3;
 let totalProgress = 4;
 
-const dummyOrgan = [
-  {
-    id: 1,
-    title: "경찰청 사이버범죄 신고시스템 (ECRM)",
-    desc: "경찰서 방문 시간 단축을 위해 사전서류 작성",
-    url: "https://www.google.com/",
-  },
-  {
-    id: 2,
-    title: "대검찰청 찐센터",
-    desc: "내가 받은 서류가 진짜일지 알고싶을 때",
-    url: "https://www.google.com/",
-  },
-  {
-    id: 3,
-    title: "은행 전화번호 진위확인 서비스",
-    desc: "피싱범에게 받은 은행 전화번호, 진짜일까?",
-    url: "https://www.google.com/",
-  },
-  {
-    id: 4,
-    title: "개인정보노출자 사고예방시스템",
-    desc: "더 이상의 개인정보 유출을 막기 위해, 명의도용 예방 시스템",
-    url: "https://www.google.com/",
-  },
-  {
-    id: 5,
-    title: "명의도용방지 서비스 M-safer",
-    desc: "명의도용이 의심될때, 내 이름으로 개통된 휴대폰 조회하기",
-    url: "https://www.google.com/",
-  },
-  {
-    id: 6,
-    title: "어카운트 인포",
-    desc: "내 명의로 개설된 계좌 및 대출 한 눈에 확인하기",
-    url: "https://www.google.com/",
-  },
-];
-
 const EmergencyMainPage = () => {
+  const navigate = useNavigate();
+  // 테스트용. 추후 서버에서 받아오기
   const hasProgress = false;
+
+  const onClickToOrganList = () => {
+    navigate("/emergency/organ-list");
+  };
   return (
     <div className="px-6 mb-10">
       <h1 className="font-bold text-2xl leading-9 mt-1 mb-4">긴급대응</h1>
@@ -71,7 +40,17 @@ const EmergencyMainPage = () => {
           <QuickReportCard title="금융감독원 (1132)" />
         </div>
         <div className="flex flex-col gap-[10px]">
-          <h2 className="font-bold text-xl leading-8">보이스피싱 대응기관들</h2>
+          <div className="flex flex-row justify-between items-center">
+            <h2 className="font-bold text-xl leading-8">
+              보이스피싱 대응기관들
+            </h2>
+            <p
+              className="text-sm text-monochrome-400"
+              onClick={onClickToOrganList}
+            >
+              전체보기
+            </p>
+          </div>
           <div className="grid grid-rows-2 grid-flow-col overflow-x-scroll gap-[10px] pb-3">
             {dummyOrgan.map((item, index) => {
               const bgColor = index % 2 === 0 ? "#EEF1F3" : "#F1F4FF";

--- a/src/pages/Emergency/OrganListPage/OrganListPage.tsx
+++ b/src/pages/Emergency/OrganListPage/OrganListPage.tsx
@@ -1,0 +1,66 @@
+import { useNavigate } from "react-router-dom";
+import { dummyOrgan } from "../organList";
+
+const OrganListPage = () => {
+  const navigate = useNavigate();
+  return (
+    <div className="flex flex-col justify-between w-full h-full">
+      <header className="w-full fixed flex flex-row justify-center items-center px-6 py-[19px] bg-monochrome-100">
+        <img
+          className="absolute left-0 p-1 ml-6"
+          src="/public/icons/ArrowLeftBlack-icon.svg"
+          alt="뒤로가기"
+          onClick={() => navigate(-1)}
+        />
+        <h1 className="text-xl text-monochrome-700 font-bold leading-8">
+          보이스피싱 대응기관
+        </h1>
+      </header>
+      <main className="mt-[72px] overflow-y-scroll flex flex-col gap-[10px] px-6 h-[calc(100vh-72px)] pb-10">
+        {dummyOrgan.map((item, index) => {
+          const bgColor = index % 2 === 0 ? "#EEF1F3" : "#F1F4FF";
+          return (
+            <div
+              key={item.id}
+              className="flex flex-col border-blur px-5 py-[14px] rounded-[15px] gap-[10px]"
+              style={{ background: `${bgColor}` }}
+            >
+              <div className="flex flex-col gap-[6px]">
+                <h3
+                  className="text-monochrome-700 font-bold text-[18px] leading-5"
+                  style={{
+                    wordBreak: "keep-all",
+                  }}
+                >
+                  {item.title}
+                </h3>
+                <span
+                  className="break-words text-monochrome-500 font-normal text-[16px] leading-6"
+                  style={{
+                    wordBreak: "keep-all",
+                  }}
+                >
+                  {item.desc}
+                </span>
+              </div>
+              <a
+                className="flex flex-row gap-[5px] justify-end"
+                href={item.url}
+              >
+                <span className="text-primary-400 font-semibold text-[14px] leading-4">
+                  사이트 바로가기
+                </span>
+                <img
+                  src="/public/icons/site-arrow-icon.svg"
+                  alt="화살표 아이콘"
+                />
+              </a>
+            </div>
+          );
+        })}
+      </main>
+    </div>
+  );
+};
+
+export default OrganListPage;

--- a/src/pages/Emergency/organList.ts
+++ b/src/pages/Emergency/organList.ts
@@ -1,0 +1,44 @@
+export const dummyOrgan = [
+  {
+    id: 1,
+    title: "경찰청 사이버범죄 신고시스템 (ECRM)",
+    desc: "경찰서 방문 시간 단축을 위해 사전서류 작성",
+    url: "https://www.google.com/",
+  },
+  {
+    id: 2,
+    title: "대검찰청 찐센터",
+    desc: "내가 받은 서류가 진짜일지 알고싶을 때",
+    url: "https://www.google.com/",
+  },
+  {
+    id: 3,
+    title: "은행 전화번호 진위확인 서비스",
+    desc: "피싱범에게 받은 은행 전화번호, 진짜일까?",
+    url: "https://www.google.com/",
+  },
+  {
+    id: 4,
+    title: "개인정보노출자 사고예방시스템",
+    desc: "더 이상의 개인정보 유출을 막기 위해, 명의도용 예방 시스템",
+    url: "https://www.google.com/",
+  },
+  {
+    id: 5,
+    title: "명의도용방지 서비스 M-safer",
+    desc: "명의도용이 의심될때, 내 이름으로 개통된 휴대폰 조회하기",
+    url: "https://www.google.com/",
+  },
+  {
+    id: 6,
+    title: "어카운트 인포",
+    desc: "내 명의로 개설된 계좌 및 대출 한 눈에 확인하기",
+    url: "https://www.google.com/",
+  },
+  {
+    id: 7,
+    title: "어카운트 인포",
+    desc: "내 명의로 개설된 계좌 및 대출 한 눈에 확인하기",
+    url: "https://www.google.com/",
+  },
+];

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -7,6 +7,7 @@ import FraudLandingPage from "../pages/FraudLandingPage/FraudLandingPage";
 import FraudSurveyPage from "../pages/FraudSurveyPage/FraudSurveyPage";
 import FraudLayout from "../layouts/FraudLayout";
 import MainLayout from "../layouts/MainLayout";
+import OrganListPage from "../pages/Emergency/OrganListPage/OrganListPage";
 
 const router = createBrowserRouter([
   {
@@ -14,7 +15,6 @@ const router = createBrowserRouter([
     element: <Navigate to="/home" replace />,
     errorElement: <NotFound />,
   },
-
   {
     path: "/",
     element: <MainLayout />,
@@ -40,6 +40,16 @@ const router = createBrowserRouter([
       {
         path: "survey",
         element: <FraudSurveyPage />,
+      },
+    ],
+  },
+  {
+    path: "/emergency",
+    children: [
+      {
+        path: "organ-list",
+        // 두 단어로 이루어진 url에는 대시(-)를 쓰는 것이 유리하다.
+        element: <OrganListPage />,
       },
     ],
   },


### PR DESCRIPTION
## 🐣Title
- 보이스피싱 대응기관 페이지 구현

<br/>

## 🐣Key Changes
- 기존 EmergencyMainPage에 있던 더미 데이터 organList.ts로 분리
- 전체보기를 클릭했을 때 보이스피싱 대응기관 페이지로 이동하도록 구현
- 기존 OrganCard를 참고하여 해당 페이지 구현

<br/>

## 🐣Simulation
![image](https://github.com/user-attachments/assets/ee84cb89-5d7c-473e-bea0-4ae0bb87088a)
![image](https://github.com/user-attachments/assets/d810e52a-31a3-43ab-bb8b-2fad5c21a56e)

<br/>

## 🐣To Reviewer
- 헤더를 따로 컴포넌트로 빼진 않았지만 앞으로 저런 식으로 사용하면 어떨 지 확인해주세요. 뒤로가기 버튼이 absolute로 되어 있어서 조금 어색할 수도 있어서 피드백 부탁드립니다.
<br/>

## 🐣Next

- 긴급 신고 가이드 부분 구현

<br/>

## 🐣Issue

- 헤더를 이런 식으로 작성해도 되는지. absolute를 요소에 줘도 되는지