### PR TITLE
feat: Header 컴포넌트 생성

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,11 +4,15 @@ type Props = {
   title: React.ReactNode;
   leftChild: React.ReactNode;
   rightChild: React.ReactNode;
+  bgColor?: string;
 };
 
-const Header = ({ title, leftChild, rightChild }: Props) => {
+const Header = ({ title, leftChild, rightChild, bgColor = "#fff" }: Props) => {
   return (
-    <header className="w-full fixed flex flex-row items-center px-6 py-[19px]">
+    <header
+      className="w-full fixed flex flex-row items-center px-6 py-[19px]"
+      style={{ background: `${bgColor}` }}
+    >
       <div className="flex-1 flex justify-start">{leftChild}</div>
       <div className="flex-3 flex justify-center">{title}</div>
       <div className="flex-1 flex justify-end">{rightChild}</div>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+type Props = {
+  title: React.ReactNode;
+  leftChild: React.ReactNode;
+  rightChild: React.ReactNode;
+};
+
+const Header = ({ title, leftChild, rightChild }: Props) => {
+  return (
+    <header className="w-full fixed flex flex-row items-center px-6 py-[19px]">
+      <div className="flex-1 flex justify-start">{leftChild}</div>
+      <div className="flex-3 flex justify-center">{title}</div>
+      <div className="flex-1 flex justify-end">{rightChild}</div>
+    </header>
+  );
+};
+
+export default Header;

--- a/src/pages/Emergency/OrganListPage/OrganListPage.tsx
+++ b/src/pages/Emergency/OrganListPage/OrganListPage.tsx
@@ -1,21 +1,26 @@
 import { useNavigate } from "react-router-dom";
 import { dummyOrgan } from "../organList";
+import Header from "../../../components/Header/Header";
 
 const OrganListPage = () => {
   const navigate = useNavigate();
   return (
     <div className="flex flex-col justify-between w-full h-full">
-      <header className="w-full fixed flex flex-row justify-center items-center px-6 py-[19px] bg-monochrome-100">
-        <img
-          className="absolute left-0 p-1 ml-6"
-          src="/public/icons/ArrowLeftBlack-icon.svg"
-          alt="뒤로가기"
-          onClick={() => navigate(-1)}
-        />
-        <h1 className="text-xl text-monochrome-700 font-bold leading-8">
-          보이스피싱 대응기관
-        </h1>
-      </header>
+      <Header
+        title={
+          <h1 className="text-xl text-monochrome-700 font-bold leading-8">
+            보이스피싱 대응기관
+          </h1>
+        }
+        leftChild={
+          <img
+            src="/public/icons/ArrowLeftBlack-icon.svg"
+            alt="뒤로가기"
+            onClick={() => navigate(-1)}
+          />
+        }
+        rightChild={<></>}
+      />
       <main className="mt-[72px] overflow-y-scroll flex flex-col gap-[10px] px-6 h-[calc(100vh-72px)] pb-10">
         {dummyOrgan.map((item, index) => {
           const bgColor = index % 2 === 0 ? "#EEF1F3" : "#F1F4FF";


### PR DESCRIPTION
## 🐣Title
- Header 컴포넌트 생성함
<br/>

## 🐣Key Changes
- title, leftChild, rightChild를 prop으로 받는 공통 Header 컴포넌트 생성
- 범용적으로 사용할 수 있도록 모든 props는 JSX로 받을 수 있도록 함.
- Header 컴포넌트에서는 상단 고정 헤더 레이아웃 정도만 지원함

<br/>

## 🐣Simulation
- 기존 OrganListPage에서 사용했던 코드를 기반으로 Header 컴포넌트를 사용하여 해당 페이지 헤더 구현

<br/>

## 🐣To Reviewer
1. 위에서 말했 듯이 title, leftChild, rightChild 모두 JSX를 prop으로 받기 때문에 각각의 스타일링 후 prop으로 전달할 수 있습니다.
2. 만약 3개의 prop 중 사용하지 않는 prop이 있다면 `<></>`을 prop으로 주면 됩니다.

<br/>
