### PR TITLE
design: 설문 페이지 부분 디자인 수정

### DIFF
--- a/src/pages/FraudSurvey/FraudMessagePage/FraudMessagePage.tsx
+++ b/src/pages/FraudSurvey/FraudMessagePage/FraudMessagePage.tsx
@@ -26,7 +26,7 @@ const FraudMessagePage = () => {
           <img src={ImgUploadIcon} alt="이미지 업로드" />
         </div>
 
-        <div className="w-[50%] h-11 px-6 py-3.5 bg-gray-100 rounded-[10px] inline-flex justify-center items-center gap-2.5">
+        <div className="h-11 px-6 py-3.5 bg-gray-100 rounded-[10px] inline-flex justify-center items-center gap-2.5">
           <div className="text-gray-400 text-lg font-medium leading-relaxed">
             캡처 이미지 첨부
           </div>

--- a/src/pages/FraudSurvey/FraudSurveyPage/FraudSurveyPage.tsx
+++ b/src/pages/FraudSurvey/FraudSurveyPage/FraudSurveyPage.tsx
@@ -3,35 +3,31 @@ import { surveyContent } from "../surveyContent";
 import { useFraudStore } from "../../../stores/fraudStore";
 
 const FraudSurveyPage = () => {
+  const { progress } = useFraudStore();
+  const currentSurvey = surveyContent.find((s) => s.progress === progress);
 
-    const { progress } = useFraudStore();
-    const currentSurvey = surveyContent.find(s => s.progress === progress);
+  return (
+    <div className="flex flex-col w-full h-full px-6">
+      <div className="mt-9 mb-9">
+        <span className="text-slate-950 text-2xl font-bold leading-9">
+          {currentSurvey?.question}
+        </span>
+        {currentSurvey?.isEssential ? (
+          <span className="text-red-500 text-2xl font-bold leading-9">*</span>
+        ) : (
+          <span className="text-zinc-300 text-2xl font-bold leading-9">
+            {" (선택)"}
+          </span>
+        )}
+      </div>
 
-    return (
-        <div className="flex flex-col w-full h-full px-6">
-            <div className="mt-9 mb-9">
-                <span className="text-slate-950 text-2xl font-bold leading-9">
-                    {currentSurvey?.question}
-                </span>
-                {currentSurvey?.isEssential ? (
-                    <span className="text-red-500 text-2xl font-bold leading-9">
-                        *
-                    </span>
-                ) : (
-                    <span className="text-zinc-300 text-2xl font-bold leading-9">
-                        {" (선택)"}
-                    </span>
-                )}
-            </div>
-
-            <div className="flex flex-col gap-4">
-                {currentSurvey?.answers.map((surveyItem) => {
-                    return <SurveyButton text={surveyItem} />
-                })}
-            </div>
-
-        </div>
-    )
-}
+      <div className="flex flex-col gap-4 pb-4">
+        {currentSurvey?.answers.map((surveyItem) => {
+          return <SurveyButton text={surveyItem} />;
+        })}
+      </div>
+    </div>
+  );
+};
 
 export default FraudSurveyPage;


### PR DESCRIPTION
## 🐣Title
- 설문 페이지 부분 디자인 수정

## 🐣Key Changes
- '캡처 이미지 첨부' 버튼 디자인에서 width 제거
- 설문조사 문항 부분 아래쪽 패딩 추가하여 스크롤 시 '다음' 버튼과 떨어지도록 수정

## 🐣Simulation
<img width="544" height="973" alt="image" src="https://github.com/user-attachments/assets/4ea2beff-cdcd-4781-b974-fabf49377c18" />

<img width="546" height="975" alt="image" src="https://github.com/user-attachments/assets/c913ef27-58f7-45fa-835c-9a5b5351e7a0" />

<img width="547" height="974" alt="image" src="https://github.com/user-attachments/assets/36920434-ff97-41d6-9c63-977dcc788b41" />


## 🐣To Reviewer
- 디자인 적으로 조금 수정하긴 했습니다.

1. 로직 관련해서 말씀드리자면 현재 설문조사 문항 중 하나를 선택하고 다시 누르면 선택 해제가 되는데 다음 버튼은 여전히 활성화 상태입니다. 비활성화로 돌리도록 수정이 필요할 것 같습니다.
2. 또한 뒤로가기를 했을 때 전 단계에서 선택한 것이 선택 해제된 상태가 되어있습니다. 이 부분도 수정이 필요합니다.
3. (이건 그냥 참고사항) 현재 화살표 버튼으로 뒤로가면 프로그레스바가 잘 줄어드는데 웹브라우저상에서 뒤로가기기를 누르면 화면적으로 오류가 발생합니다. 추후 수정이 가능하다면 좋은 부분일 것 같습니다.

<img width="536" height="135" alt="image" src="https://github.com/user-attachments/assets/167d7624-9f9c-40e7-8c29-588c947b6e72" />
