### PR TITLE
feat: 설문 선택 로직 개선, 지난 선택 로컬스토리지 기억기능 추가

### DIFF
--- a/src/layouts/FraudLayout.tsx
+++ b/src/layouts/FraudLayout.tsx
@@ -1,25 +1,42 @@
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import Button from "../components/Button/Button";
-import { useFraudStore } from "../stores/fraudStore";
+import { STEP_CONFIG, useFraudStore } from "../stores/fraudStore";
 import LeftArrowWhiteIcon from "../assets/icons/arrow-left-white-icon.svg";
 import LeftArrowIcon from "../assets/icons/arrow-left-darkblue-icon.svg";
 
 const FraudLayout = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const {
-    selectedAnswer,
-    progress,
-    setProgress,
-    recordAnswerAndProceed,
-    reset,
-  } = useFraudStore();
+
   const heightSize =
     location.pathname === "/fraud-analysis"
       ? "h-[calc(100vh-48px)]"
       : "h-[calc(100vh-140px)]";
 
+  const {
+    currentStepAnswers,
+    progress,
+    setProgress,
+    recordAnswerAndProceed,
+    reset,
+  } = useFraudStore();
+
+  const currentConfig = STEP_CONFIG[progress];
+
+
+  const canProceed = () => {
+    if (!currentConfig)
+      return false;
+    if (currentConfig.isRequired) {
+      return currentStepAnswers.length > 0 && currentStepAnswers[0] !== "";
+    }
+
+    return true;
+  }
+
+
   const handleBackClick = () => {
+
     console.log("현재 백클릭에서의 progress : ", progress);
     if (progress <= 1) {
       reset();
@@ -33,6 +50,10 @@ const FraudLayout = () => {
   };
 
   const handleBtnClick = () => {
+    if (!canProceed()) {
+      alert("답변을 선택해주세요");
+      return
+    }
     recordAnswerAndProceed(navigate);
   };
 
@@ -57,8 +78,8 @@ const FraudLayout = () => {
           <div className="w-full h-1.5 relative">
             <div className="w-full h-[5px] left-0 top-0 absolute bg-gray-200" />
             <div
-              className="h-[5px] left-0 top-0 absolute bg-blue-500 rounded-tr-[90px] rounded-br-[90px]"
-              style={{ width: `${progress * 10}%` }}
+              className="h-[5px] left-0 top-0 absolute bg-blue-500 rounded-tr-[90px] rounded-br-[90px] transition-all duration-300"
+              style={{ width: `${progress / 9 * 100}%` }}
             />
           </div>
         </div>
@@ -76,7 +97,7 @@ const FraudLayout = () => {
             onClick={handleBtnClick}
             size="lg"
             isHighlight={false}
-            disabled={selectedAnswer === null && progress < 7}
+            disabled={!canProceed()}
           >
             다음
           </Button>

--- a/src/pages/FraudSurvey/FraudSurveyPage/FraudSurveyPage.tsx
+++ b/src/pages/FraudSurvey/FraudSurveyPage/FraudSurveyPage.tsx
@@ -4,6 +4,7 @@ import { useFraudStore } from "../../../stores/fraudStore";
 
 const FraudSurveyPage = () => {
   const { progress } = useFraudStore();
+
   const currentSurvey = surveyContent.find((s) => s.progress === progress);
 
   return (
@@ -23,8 +24,9 @@ const FraudSurveyPage = () => {
 
       <div className="flex flex-col gap-4 pb-4">
         {currentSurvey?.answers.map((surveyItem) => {
-          return <SurveyButton text={surveyItem} />;
+          return <SurveyButton key={`${progress}-${surveyItem}`} text={surveyItem} />;
         })}
+
       </div>
     </div>
   );

--- a/src/pages/FraudSurvey/FraudSurveyPage/components/SurveyButton.tsx
+++ b/src/pages/FraudSurvey/FraudSurveyPage/components/SurveyButton.tsx
@@ -1,24 +1,48 @@
-import { useFraudStore } from "../../../../stores/fraudStore";
+import { STEP_CONFIG, useFraudStore } from "../../../../stores/fraudStore";
 
 interface SurveyButtonProps {
     text: string;
 }
 
+
 const SurveyButton = ({ text }: SurveyButtonProps) => {
-    const { selectedAnswer, selectAnswer } = useFraudStore();
+
+    // const { progress, currentStepAnswers,
+    // toggleAnswer, setSingleAnswer, setBooleanAnswer } = useFraudStore();
+    const { progress, currentStepAnswers,
+        toggleAnswer, setSingleAnswer } = useFraudStore();
+
+
+    const currentConfig = STEP_CONFIG[progress];
+    const isSelected = currentStepAnswers.includes(text);
+
+    const handleClick = () => {
+        if (!currentConfig)
+            return;
+
+        if (currentConfig.isMultiple) {
+            toggleAnswer(text);
+        } else {
+            if (isSelected) {
+                setSingleAnswer('');
+            } else {
+                setSingleAnswer(text);
+            }
+        }
+    };
 
     return (
         <div className="w-full">
-            {selectedAnswer === text ? (
+            {isSelected ? (
                 <div data-property-1="Selected" className="w-full h-15 px-4 py-3.5 bg-blue-300 rounded-xl inline-flex justify-center items-center gap-1.5"
-                    onClick={() => selectAnswer("")}>
+                    onClick={handleClick}>
                     <div className="text-white text-xl font-bold leading-loose">
                         {text}
                     </div>
                 </div>
             ) : (
                 <div data-property-1="Default" className="w-full h-15 px-4 py-3.5 bg-gray-100 rounded-xl inline-flex justify-center items-center gap-1.5"
-                    onClick={() => selectAnswer(text)}>
+                    onClick={handleClick}>
                     <div className="text-slate-950 text-xl font-semibold leading-loose">
                         {text}
                     </div>

--- a/src/types/fraud-types.ts
+++ b/src/types/fraud-types.ts
@@ -1,0 +1,26 @@
+export interface SurveyAnswers {
+    contactMethod?: string;              // 설문1 - 단일 선택
+    counterpart?: string;                // 설문2 - 단일 선택  
+    requestedAction?: string[];          // 설문3 - 다중 선택
+    requestedInfo?: string[];            // 설문4 - 다중 선택
+    appType?: string;                    // 설문5 - 단일 선택 (선택사항)
+    atmGuided?: string;                 // 설문6 - 단일 선택 (선택사항)
+    suspiciousLinks?: string[];          // 설문7 - 다중 선택 (선택사항)
+    suspiciousPhoneNumbers?: string[];   // 설문7 - 다중 선택 (선택사항)
+    imageUrls?: string[];                // 설문8 - 다중 선택 (선택사항)
+    messageContent?: string;             // 설문8 - 단일 선택 (선택사항)
+    additionalDescription?: string;      // 설문9 - 단일 선택 (선택사항)
+}
+
+//추후 api 연결 시, boolean 설문 별도 처리를 위해서 사용 예정
+export type SurveyAnswersSendingFormat = Omit<SurveyAnswers, 'atmGuided'> & {
+    atmGuided: boolean;
+};
+
+export interface StepConfig {
+    key: keyof SurveyAnswers;
+    isMultiple: boolean;
+    isRequired: boolean;
+}
+
+export type Status = 'idle' | 'loading' | 'success' | 'error';


### PR DESCRIPTION
## 🐣Title

feat: 설문 선택 로직 개선, 지난 선택 로컬스토리지 기억기능 추가

<br/>

## 🐣Key Changes

- 백엔드 API 참고하여, 설문 답변 형태 재설계
```
export const STEP_CONFIG: Record<number, StepConfig> = {
    1: { key: 'contactMethod', isMultiple: false, isRequired: true },
    2: { key: 'counterpart', isMultiple: false, isRequired: true },
    3: { key: 'requestedAction', isMultiple: true, isRequired: true },
    4: { key: 'requestedInfo', isMultiple: true, isRequired: true },
    5: { key: 'appType', isMultiple: false, isRequired: false },
    6: { key: 'atmGuided', isMultiple: false, isRequired: false },
    7: { key: 'suspiciousLinks', isMultiple: true, isRequired: false }, // 또는 suspiciousPhoneNumbers
    8: { key: 'imageUrls', isMultiple: true, isRequired: false }, // 또는 messageContent
    9: { key: 'additionalDescription', isMultiple: false, isRequired: false },
};
```

> fraudStore.ts : 
- 새로운 답변 형태에 맞게 store 변수-함수 재작성
  - 다중 선택 허용
  - 사전 설정된 데이터 구조 반영
  - 지난 선택 값 불러오기 기능 추가

types/fraud-types.ts : 설문 답변 관련 타입 정리


<br/>

## 🐣Simulation

<img width="751" height="1339" alt="image" src="https://github.com/user-attachments/assets/baf98ff8-a5ea-41b1-8755-7aeaa411e3a3" />

<br/>

## 🐣To Reviewer

> fraudLandingPage를 fraudLayout에서 빼내고 단독 페이지로 구현하는 게 더 낫겠다는 생각이 들어 시도해볼 생각입니다.

<br/>

## 🐣Next

1. landingPage UI 개선
2. 설문 직접 삽입 항목 기능 구현

<br/>

## 🐣Issue

> fraudStore.ts에서 시간이 지나치게 소요되어서 as any로 처리한 부분이 존재.
key값에 대한 unused 경고 존재.
➡️ 해당 줄에 대해 eslint disable 처리, 추후 여유있을 시 개선하는게 좋을 것 같습니다.

<br/>