### PR TITLE
design: 사기분석 설문 부분 ui 디자인 수정

### DIFF
--- a/src/layouts/FraudLayout.tsx
+++ b/src/layouts/FraudLayout.tsx
@@ -3,6 +3,7 @@ import Button from "../components/Button/Button";
 import LeftArrowIcon from "../assets/icons/arrow-left-darkblue-icon.svg";
 import { useMemo } from "react";
 import { useFraudSurvey } from "../hooks/useFraudSurvey";
+import Header from "../components/Header/Header";
 
 export type AnswerValue = string | string[] | File[];
 export type SurveyAnswers = {
@@ -40,37 +41,37 @@ const FraudLayout = () => {
   };
 
   // 4. Context로 전달하는 값을 최소화
-  const contextValue = useMemo(() => ({
-    allAnswers,
-    updateAnswers,
-    progress
-  }), [allAnswers, updateAnswers, progress]);
+  const contextValue = useMemo(
+    () => ({
+      allAnswers,
+      updateAnswers,
+      progress,
+    }),
+    [allAnswers, updateAnswers, progress]
+  );
 
   return (
     <div className="flex flex-col justify-between w-full h-full">
-
-      <div className="w-full h-12">
-        <div className="flex justify-start pl-6 pt-3.5 pb-3.5">
+      <Header
+        leftChild={
           <button onClick={handleBackClick}>
             <img src={LeftArrowIcon} alt="뒤로가기" />
           </button>
-        </div>
-
-        <div className="w-full h-1.5 relative">
-          <div className="w-full h-[5px] left-0 top-0 absolute bg-gray-200" />
-          <div
-            className="h-[5px] left-0 top-0 absolute bg-blue-500 rounded-tr-[90px] rounded-br-[90px] transition-all duration-300"
-            style={{ width: `${progress / 9 * 100}%` }}
-          />
-        </div>
+        }
+      />
+      <div className="w-full h-1.5 fixed mt-[57px]">
+        <div className="w-full h-[5px] left-0 top-0 absolute bg-gray-200" />
+        <div
+          className="h-[5px] left-0 top-0 absolute bg-blue-500 rounded-tr-[90px] rounded-br-[90px] transition-all duration-300"
+          style={{ width: `${(progress / 9) * 100}%` }}
+        />
       </div>
-
       <main
         className="h-[calc(100vh-140px)] bg-[#ffffff] 
-        overflow-hidden overflow-y-auto no-scrollbar">
+        overflow-hidden overflow-y-auto no-scrollbar mt-15"
+      >
         <Outlet context={contextValue} /> {/* 사기분석 설문 내용 렌더링 */}
       </main>
-
       {location.pathname === "/fraud-analysis" ? null : (
         <div className="ml-6 mr-6 mb-8">
           <Button
@@ -87,4 +88,3 @@ const FraudLayout = () => {
   );
 };
 export default FraudLayout;
-

--- a/src/pages/FraudSurvey/AnalysisLoadingPage/AnalysisLoadingPage.tsx
+++ b/src/pages/FraudSurvey/AnalysisLoadingPage/AnalysisLoadingPage.tsx
@@ -1,25 +1,28 @@
 import { useNavigate } from "react-router-dom";
 import LeftArrowIcon from "../../../assets/icons/arrow-left-darkblue-icon.svg";
-import BlockeeGlitered from "../../../assets/characters/blockee-glitering.svg"
+import BlockeeGlitered from "../../../assets/characters/blockee-glitering.svg";
+import Header from "../../../components/Header/Header";
 const AnalysisLoadingPage = () => {
   const navigate = useNavigate();
   return (
-    <div className="flex flex-col w-full h-full px-6 justify-center items-center">
-      <div className="w-full h-12 flex justify-start">
-        <button onClick={() => navigate(-1)}>
-          <img src={LeftArrowIcon} alt="뒤로가기" />
-        </button>
+    <div className="flex flex-col w-full h-full">
+      <Header
+        leftChild={
+          <button onClick={() => navigate(-1)}>
+            <img src={LeftArrowIcon} alt="뒤로가기" />
+          </button>
+        }
+      />
+      <div className="relative h-[calc(100vh-70px)] pb-10 flex flex-col px-6 mt-[70px] justify-center items-center gap-4">
+        <div className="flex flex-col gap-1 items-center">
+          <h1 className="font-bold text-2xl leading-9">결과 진단 중</h1>
+          <p className="text-primary-300 font-medium text-lg leading-7">
+            잠시만 기다려주세요
+          </p>
+        </div>
+        <img src={BlockeeGlitered} alt="캐릭터" />
       </div>
-      <div className="mt-40 text-center text-black text-2xl font-bold font-['Pretendard'] leading-9">
-        결과 진단 중
-      </div>
-      <div className="mb-25 text-center text-blue-300 text-lg font-medium font-['Pretendard'] leading-relaxed">
-        잠시만 기다려주세요
-      </div>
-
-      <img src={BlockeeGlitered} alt="캐릭터" className="w-144 h-128 mt-27" />
-      {/* <img src={BlockeeGlitered} alt="캐릭터" className="w-44 h-28 mt-27" /> */}
-    </div >
+    </div>
   );
 };
 

--- a/src/pages/FraudSurvey/FraudLandingPage/FraudLandingPage.tsx
+++ b/src/pages/FraudSurvey/FraudLandingPage/FraudLandingPage.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 import HomeBgShieild from "../../../assets/home-background-shield-image.svg";
 import Blockee from "../../../assets/character-cropped-fit-image.svg";
 import LeftArrowWhiteIcon from "../../../assets/icons/arrow-left-white-icon.svg";
+import Header from "../../../components/Header/Header";
 
 const FraudLandingPage = () => {
   const navigate = useNavigate();
@@ -9,27 +10,26 @@ const FraudLandingPage = () => {
     navigate("/fraud-analysis/survey/1-6");
   };
   return (
-    <div
-      className="w-full h-[100vh] relative p-6 bg-primary-400 box-border"
-    >
-
-      <div className="w-full h-12 bg-primary-400 outline-none">
-        <div className="flex justify-start">
+    <div className="w-full h-full flex bg-primary-400 box-border">
+      <Header
+        leftChild={
           <button onClick={() => navigate("/home")}>
             <img src={LeftArrowWhiteIcon} alt="뒤로가기" />
           </button>
-        </div>
-      </div>
-
-      <div className="flex flex-col justify-between h-[84%] border-box" onClick={handleClick}>
-
+        }
+        bgColor="#437efc"
+      />
+      <div
+        className="flex flex-col justify-between h-[calc(100vh-57px)] border-box p-6 mt-[57px]"
+        onClick={handleClick}
+      >
         <div>
           <div className="text-white text-3xl font-extrabold leading-loose">
             AI 사기유형 진단 서비스
           </div>
 
           <div className="text-gray-200 text-lg font-normal leading-relaxed">
-            의심스러운 연락을 받았다면 <br/> 지금 피싱여부를 진단해보세요!
+            의심스러운 연락을 받았다면 <br /> 지금 피싱여부를 진단해보세요!
           </div>
 
           <img src={HomeBgShieild} className="absolute right-0 top-33" />
@@ -37,12 +37,12 @@ const FraudLandingPage = () => {
 
         <div>
           <div className="w-full mb-5 text-white text-xl font-medium leading-normal">
-            ‘AI 사기유형 진단 서비스’는 피싱 상황이 의심될 때 대화 내용 분석을 통해
-            위험 상황을 판단해 주는 서비스예요.
+            ‘AI 사기유형 진단 서비스’는 피싱 상황이 의심될 때 대화 내용 분석을
+            통해 위험 상황을 판단해 주는 서비스예요.
           </div>
           <div className="w-full text-white text-xl font-medium leading-normal">
-            분석을 위해 진행되는 사전 설문을 꼼꼼히 입력해 주실수록 진단의 정확도가
-            올라가요.
+            분석을 위해 진행되는 사전 설문을 꼼꼼히 입력해 주실수록 진단의
+            정확도가 올라가요.
           </div>
 
           <div className="flex justify-end z-0 my-10">
@@ -52,10 +52,8 @@ const FraudLandingPage = () => {
             화면을 터치하여 시작하세요!
           </div>
         </div>
-
       </div>
-    </div >
-
+    </div>
   );
 };
 


### PR DESCRIPTION
## 🐣Title

- 사기분석 설문 부분 ui 디자인 수정

## 🐣Key Changes
- 모든 페이지 헤더는 공통 컴포넌트 Header 사용하여 구현
- 헤더를 제외한 메인부분은 헤더 크기를 제외한 만큼 height를 갖고 헤더만큼 margin-top 하도록 구현함
- 분석 로딩 페이지 ui 수정

<br/>

## 🐣Simulation

<img width="462" height="1007" alt="image" src="https://github.com/user-attachments/assets/29891660-eaa2-4265-bdaf-023f7aef0144" />
<img width="463" height="1007" alt="image" src="https://github.com/user-attachments/assets/06cd6cda-cac5-43cc-b303-e2f4c75646d9" />
<img width="465" height="1007" alt="image" src="https://github.com/user-attachments/assets/2a6f3506-1a3a-4145-a255-622f259def2a" />

<br/>

## 🐣To Reviewer
- 앞으로 헤더는 무조건 공통 컴포넌트 사용해서 구현하는 것을 추천드립니다. fixed 인 상태가 마음에 안드신다면 다른 의견 주셔도 괜찮습니다.

<br/>
